### PR TITLE
Add Python 3.9 support and update PyPI classifiers

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,10 @@ setup(
         'Operating System :: OS Independent',
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development"
     ],
     python_requires='<4',


### PR DESCRIPTION
Add Python 3.9 to GHA (any reason to keep 2.7 in travis?)

Update PyPI classifiers with the used Python versions